### PR TITLE
V1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ This output is then parsed by a custom python script to generate a file that can
 1. BAM file. This BAM file should be the same as used for variant calling, following all preprocessing.
 2. The associated BAM file index (.bai)
 3. A bed file in the sambamba format. This file is created by MokaBED and named in format Pan123sambamba.bed. 
-4. The minimum read depth required (integer). 
+4. The minimum read depth/coverage required (integer, default = 150). 
 5. Count overlapping mate reads once? This True/False boolean denotes whether to apply the -m flag. True counts overlapping mate reads once (default) whereas False counts each overlapping mate read seperately.
 6. Min base quality to be included (default = 25)
-
+7. Min mapping quality score to be included (default = 20)
+8. Exclude duplicate reads? This True/False boolean denotes whether to filter out reads that have failed quality control `- F not failed_quality_control`. True excludes reads that have failed quality control, false includes them.
+9. There is an `additional_options` free form text box for passing additional flags to Sambamba, this excludes arguments passed as a text string to the -F filter flag.
 
 ## What does this app output?
 This app produces five outputs:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This output is then parsed by a custom python script to generate a file that can
 1. BAM file. This BAM file should be the same as used for variant calling, following all preprocessing.
 2. The associated BAM file index (.bai)
 3. A bed file in the sambamba format. This file is created by MokaBED and named in format Pan123sambamba.bed. 
-4. The minimum read depth/coverage required (integer, default = 150). 
+4. The minimum read depth/coverage required (integer). 
 5. Count overlapping mate reads once? This True/False boolean denotes whether to apply the -m flag. True counts overlapping mate reads once (default) whereas False counts each overlapping mate read seperately.
 6. Min base quality to be included (default = 25)
 7. Min mapping quality score to be included (default = 20)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dnanexus_sambamba_chanjo - v1.10
+# dnanexus_sambamba_chanjo - v1.11
 
 ## What does this app do?
 This app utilises Chanjo and Sambamba to calculates coverage.
@@ -11,6 +11,7 @@ The `sambamba depth region` function is used with the following arguments:
 * -t `nproc`    -   Utilise multiple threads - uses the total number of threads available.
 * -m    -   Does not count overlapping mate reads more than once.
 * -F "mapping_quality >= 20"    - Uses the BAM flag mapping quality to only count bases with a mapping quality >=20
+* -q    -   Min base quality for that base to be counted.
 
 The sambamba output records the number of bases (that meet the parameters set) within each region of the bed file which have the required read depth.
 
@@ -32,6 +33,7 @@ This output is then parsed by a custom python script to generate a file that can
 3. A bed file in the sambamba format. This file is created by MokaBED and named in format Pan123sambamba.bed. 
 4. The minimum read depth required (integer). 
 5. Count overlapping mate reads once? This True/False boolean denotes whether to apply the -m flag. True counts overlapping mate reads once (default) whereas False counts each overlapping mate read seperately.
+6. Min base quality to be included (default = 25)
 
 
 ## What does this app output?

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ The `sambamba depth region` function is used with the following arguments:
 
 * -L bedfile    -   Only counts regions stated in the bedfile
 * -T n -   The required read depth (integer). For example, WES requires a minimum read depth of 20X, custom panels 30X whilst Oncology samples require a much higher read depth.
-* -t `nproc`    -   Utilise multiple threads - uses the total number of threads available.
+* -t $(nproc)    -   Utilise multiple threads - uses the total number of threads available.
 * -m    -   Does not count overlapping mate reads more than once.
-* -F "mapping_quality >= 20"    - Uses the BAM flag mapping quality to only count bases with a mapping quality >=20
+* -F "mapping_quality 20 and not failed_quality_control and not duplicate"    - DEFAULT: Uses the BAM flag mapping quality to only count bases with a mapping quality >=20, which have passed QC, and are not duplicates.
 * -q    -   Min base quality for that base to be counted.
 
 The sambamba output records the number of bases (that meet the parameters set) within each region of the bed file which have the required read depth.
@@ -36,7 +36,8 @@ This output is then parsed by a custom python script to generate a file that can
 6. Min base quality to be included (default = 25)
 7. Min mapping quality score to be included (default = 20)
 8. Exclude duplicate reads? This True/False boolean denotes whether to filter out reads that have failed quality control `- F not failed_quality_control`. True excludes reads that have failed quality control, false includes them.
-9. There is an `additional_options` free form text box for passing additional flags to Sambamba, this excludes arguments passed as a text string to the -F filter flag.
+9. There is an `additional_sambamba_flags` free form text box for passing additional flags to Sambamba, this excludes arguments passed as a text string to the -F filter flag.
+10. There is an `additional_filter_commands` free form text box for passing additional arguments as a text string to the Sambamba -F filter flag.  Commands are appended to the existing filter so the text must start ` and ...`, where ... is the additional filter command (also note the leading space before `and`). 
 
 ## What does this app output?
 This app produces five outputs:

--- a/dxapp.json
+++ b/dxapp.json
@@ -62,8 +62,7 @@
       "name": "coverage_level",
       "label": "coverage level",
       "help": "The level of coverage to be reported.",
-      "class": "string",
-      "default": "150"
+      "class": "string"
     },
     {
       "name": "additional_sambamba_flags",

--- a/dxapp.json
+++ b/dxapp.json
@@ -15,21 +15,27 @@
       "label": "sambamba_bed",
       "help": "A samamba bedfile.",
       "class": "file",
-      "patterns": ["*.bed"]
+      "patterns": [
+        "*.bed"
+      ]
     },
     {
       "name": "bamfile",
       "label": "bamfile",
       "help": "bam file.",
       "class": "file",
-      "patterns": ["*.bam"]
+      "patterns": [
+        "*.bam"
+      ]
     },
     {
       "name": "bam_index",
       "label": "bamfile_index",
       "help": "bam index.",
       "class": "file",
-      "patterns": ["*.bai"]
+      "patterns": [
+        "*.bai"
+      ]
     },
     {
       "name": "merge_overlapping_mate_reads",
@@ -50,6 +56,13 @@
       "help": "The minimum base quality score required to be counted.",
       "class": "int",
       "default": 25
+    }
+    {
+      "name": "min_mapping_qual",
+      "label": "min mapping quality score",
+      "help": "The minimum mapping quality score required to be counted.",
+      "class": "int",
+      "default": 20
     }
   ],
   "outputSpec": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -45,10 +45,39 @@
       "default": true
     },
     {
+      "name": "exclude_failed_quality_control",
+      "label": "Exclude reads which have failed quality_control",
+      "help": "Should reads which have failed quality_control be excluded? True = Exclude. False = Include",
+      "class": "boolean",
+      "default": true
+    },
+    {
+      "name": "exclude_duplicate_reads",
+      "label": "Exclude duplicate reads",
+      "help": "Should duplicate reads be excluded? True = Exclude. False = Include",
+      "class": "boolean",
+      "default": true
+    },
+    {
       "name": "coverage_level",
       "label": "coverage level",
       "help": "The level of coverage to be reported.",
-      "class": "string"
+      "class": "string",
+      "default": "150"
+    },
+    {
+      "name": "additional_sambamba_flags",
+      "label": "Additional Sambamba flags",
+      "help": "Free form text field to send additional flag options to Sambamba",
+      "class": "string",
+      "default": ""
+    },
+    {
+      "name": "additional_filter_commands",
+      "label": "Additional Sambamba filter commands",
+      "help": "Free form text field to send additional filter options to Sambamba (text most start ' and ')",
+      "class": "string",
+      "default": ""
     },
     {
       "name": "min_base_qual",

--- a/dxapp.json
+++ b/dxapp.json
@@ -56,7 +56,7 @@
       "help": "The minimum base quality score required to be counted.",
       "class": "int",
       "default": 25
-    }
+    },
     {
       "name": "min_mapping_qual",
       "label": "min mapping quality score",

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,12 +1,12 @@
 {
-  "name": "chanjo_sambamba_coverage_v1.10",
-  "title": "coverage using sambamba and chanjo v1.10",
-  "summary": "v1.10 - coverage using sambamba and chanjo",
+  "name": "chanjo_sambamba_coverage_v1.11",
+  "title": "coverage using sambamba and chanjo v1.11",
+  "summary": "v1.11 - coverage using sambamba and chanjo",
   "tags": [
     "coverage"
   ],
   "properties": {
-    "github release": "v1.10"
+    "github release": "v1.11"
   },
   "dxapi": "1.0.0",
   "inputSpec": [
@@ -36,13 +36,20 @@
       "label": "count overlapping mate reads once",
       "help": "Should overlapping mate reads be counted once? True = counted once. False = counted twice",
       "class": "boolean",
-      "default":true
+      "default": true
     },
     {
       "name": "coverage_level",
       "label": "coverage level",
       "help": "The level of coverage to be reported.",
       "class": "string"
+    },
+    {
+      "name": "min_base_qual",
+      "label": "min base quality score (-q)",
+      "help": "The minimum base quality score required to be counted.",
+      "class": "int",
+      "default": 25
     }
   ],
   "outputSpec": [
@@ -74,21 +81,19 @@
         "name": "sqlite3"
       }
     ],
-    "systemRequirementsByRegion": {
-      "aws:us-east-1": {
-        "main": {
-          "instanceType": "mem1_ssd1_x2"
-        }
-      }
-    },
-    "systemRequirements": {
-      "main": {
-        "instanceType": "mem1_ssd1_x2"
-      }
-    },
     "file": "src/code.sh",
     "release": "14.04",
     "interpreter": "bash",
     "distribution": "Ubuntu"
+  },
+  "ignoreReuse": false,
+  "regionalOptions": {
+    "aws:us-east-1": {
+      "systemRequirements": {
+        "main": {
+          "instanceType": "mem1_ssd1_x2"
+        }
+      }
+    }
   }
 }

--- a/src/code.sh
+++ b/src/code.sh
@@ -35,7 +35,7 @@ if [[ "$merge_overlapping_mate_reads" == true ]]; then
 	opts="$opts -m"
 fi
 
-sambamba depth region -L bedfile -t "$(nproc)"  "$opts" -F "mapping_quality >= 20" "$bamfile_prefix".bam > sambamba_output.bed
+sambamba depth region -L bedfile -t "$(nproc)"  "$opts" -F "mapping_quality >= 20 and not duplicate and not failed_quality_control" "$bamfile_prefix".bam > sambamba_output.bed
 
 
 

--- a/src/code.sh
+++ b/src/code.sh
@@ -35,7 +35,7 @@ if [[ "$merge_overlapping_mate_reads" == true ]]; then
 	opts="$opts -m"
 fi
 
-sambamba depth region -L bedfile -t "$(nproc)"  "$opts" -F "mapping_quality >= 20 and not duplicate and not failed_quality_control" "$bamfile_prefix".bam > sambamba_output.bed
+sambamba depth region -L bedfile -t "$(nproc)"  "$opts" -F "$min_mapping_qual >= 20 and not duplicate and not failed_quality_control" "$bamfile_prefix".bam > sambamba_output.bed
 
 
 

--- a/src/code.sh
+++ b/src/code.sh
@@ -34,13 +34,13 @@ PATH=/home/dnanexus/miniconda2/bin:$PATH
 if [[ "$exclude_failed_quality_control" == true ]]; then
 	filter_command="mapping_quality >= ${min_mapping_qual} and not failed_quality_control"
 else
-	filter_command="mapping_quality >= ${min_mapping_qual} and failed_quality_control"
+	filter_command="mapping_quality >= ${min_mapping_qual}"
 fi
 
 if [[ "$exclude_duplicate_reads" == true ]]; then
 	filter_command="${filter_command} and not duplicate"
 else
-	filter_command="${filter_command} and duplicate"
+	filter_command="${filter_command}"
 fi
 
 dqt='"' # Assign double quote to variable - avoids escape characters and issues they were causing with teh command

--- a/src/code.sh
+++ b/src/code.sh
@@ -35,7 +35,7 @@ if [[ "$merge_overlapping_mate_reads" == true ]]; then
 	opts="$opts -m"
 fi
 
-sambamba depth region -L bedfile -t `nproc`  $opts -F "mapping_quality >= 20" $bamfile_prefix.bam > sambamba_output.bed
+sambamba depth region -L bedfile -t "$(nproc)"  "$opts" -F "mapping_quality >= 20" "$bamfile_prefix".bam > sambamba_output.bed
 
 
 

--- a/src/code.sh
+++ b/src/code.sh
@@ -29,16 +29,27 @@ PATH=/home/dnanexus/miniconda2/bin:$PATH
 # -F allows filtering using other BAM info eg mapping quality
 # check if -m flag is required
 
-opts="-T $coverage_level -q $min_base_qual"
+# build command to send to sambamba filter 
 
-if [[ "$merge_overlapping_mate_reads" == true ]]; then
-	opts="$opts -m"
+if [[ "$exclude_failed_quality_control" == true ]]; then
+	filter_command="mapping_quality >= ${min_mapping_qual} and not failed_quality_control"
+else
+	filter_command="mapping_quality >= ${min_mapping_qual} and failed_quality_control"
 fi
 
-sambamba depth region -L bedfile -t "$(nproc)"  "$opts" -F "$min_mapping_qual >= 20 and not duplicate and not failed_quality_control" "$bamfile_prefix".bam > sambamba_output.bed
+if [[ "$exclude_duplicate_reads" == true ]]; then
+	filter_command="${filter_command} and not duplicate"
+else
+	filter_command="${filter_command} and duplicate"
+fi
 
+dqt='"' # Assign double quote to variable - avoids escape characters and issues they were causing with teh command
 
-
+if [[ "$merge_overlapping_mate_reads" == true ]]; then
+	eval "sambamba depth region -L bedfile -t $(nproc) -T ${coverage_level} -q ${min_base_qual} ${additional_sambamba_flags} -m -F ${dqt}${filter_command}${additional_filter_commands}${dqt} ${bamfile_prefix}.bam" > sambamba_output.bed
+else
+	eval "sambamba depth region -L bedfile -t $(nproc) -T ${coverage_level} -q ${min_base_qual} ${additional_sambamba_flags} -F ${dqt}${filter_command}${additional_filter_commands}${dqt} ${bamfile_prefix}.bam" > sambamba_output.bed
+fi
 
 # chanjo can be modified using a yaml config file. The threshold level can be specified here using coverage_level input.
 printf "database: coverage.sqlite3\nsambamba:\n  cov_treshold:\n  - $coverage_level" > /home/dnanexus/chanjo.yaml

--- a/src/code.sh
+++ b/src/code.sh
@@ -28,11 +28,16 @@ PATH=/home/dnanexus/miniconda2/bin:$PATH
 # -m does not count overlapping mate reads more than once
 # -F allows filtering using other BAM info eg mapping quality
 # check if -m flag is required
+
+opts="-T $coverage_level -q $min_base_qual"
+
 if [[ "$merge_overlapping_mate_reads" == true ]]; then
-	sambamba depth region -L bedfile -t `nproc` -T $coverage_level -m -F "mapping_quality >= 20" $bamfile_prefix.bam > sambamba_output.bed
-else
-	sambamba depth region -L bedfile -t `nproc` -T $coverage_level -F "mapping_quality >= 20" $bamfile_prefix.bam > sambamba_output.bed
+	opts="$opts -m"
 fi
+
+sambamba depth region -L bedfile -t `nproc`  $opts -F "mapping_quality >= 20" $bamfile_prefix.bam > sambamba_output.bed
+
+
 
 
 # chanjo can be modified using a yaml config file. The threshold level can be specified here using coverage_level input.


### PR DESCRIPTION
The release adds additional options to the app:

The ability to filter reads on:
- exclude_failed_quality_control
- exclude_duplicate_reads
- Set min_mapping_qual used in filter

The app also now allows the user to set:
- min_base_qual
- required coverage_level
-  Whether to count overlapping mate reads more than once

Also there is the ability to pass _ad hoc_ options or filters to Sambamba

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/dnanexus_sambamba_chanjo/33)
<!-- Reviewable:end -->
